### PR TITLE
Fix WebRTC algorithm integration.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -593,7 +593,7 @@ Integration with WebRTC {#rtc}
 -----------------------
 
 To constrain WebRTC connections, [[webrtc]] can call into the [$should WebRTC be blocked by Connection Allowlists$]
-algorithm while determining whether candidates are <a spec="webrtc">administratively prohibited</a>.
+algorithm during the invocation of the {{RTCPeerConnection}} {{RTCPeerConnection/constructor}}.
 
 
 Security and Privacy Considerations {#security}


### PR DESCRIPTION
In the Chromium implementation for WebRTC handling, we determine if it is allowed or blocked during construction of the RTCPeerConnection object. The spec currently states that we can do so when determining if individual candidates are administratively prohibited. Given that construction happens before adding individual candidates, the spec should be updated accordingly.